### PR TITLE
Feature/unlink requester secrets provisioning from application

### DIFF
--- a/src/itest/java/com/iexec/sms/ApiClient.java
+++ b/src/itest/java/com/iexec/sms/ApiClient.java
@@ -28,7 +28,7 @@ public interface ApiClient {
     String API_URL = "http://localhost:${local.server.port}";
 
     @PostMapping("/apps/{appAddress}/secrets/{secretIndex}")
-    ResponseEntity<ApiResponseBody<String>> addRequesterAppComputeSecret(
+    ResponseEntity<ApiResponseBody<String>> addAppDeveloperAppComputeSecret(
             @RequestHeader("Authorization") String authorization,
             @PathVariable String appAddress,
             @PathVariable long secretIndex,
@@ -47,19 +47,17 @@ public interface ApiClient {
             @PathVariable String appAddress,
             @RequestBody int secretCount);
 
-    @PostMapping("/requesters/{requesterAddress}/apps/{appAddress}/secrets/{secretIndex}")
+    @PostMapping("/requesters/{requesterAddress}/secrets/{secretIndex}")
     ResponseEntity<ApiResponseBody<String>> addRequesterAppComputeSecret(
             @RequestHeader("Authorization") String authorization,
             @PathVariable String requesterAddress,
-            @PathVariable String appAddress,
             @PathVariable long secretIndex,
             @RequestBody String secretValue
     );
 
-    @RequestMapping(method = RequestMethod.HEAD, path = "/requesters/{requesterAddress}/apps/{appAddress}/secrets/{secretIndex}")
+    @RequestMapping(method = RequestMethod.HEAD, path = "/requesters/{requesterAddress}/secrets/{secretIndex}")
     ResponseEntity<ApiResponseBody<String>> isRequesterAppComputeSecretPresent(
             @PathVariable String requesterAddress,
-            @PathVariable String appAddress,
             @PathVariable long secretIndex
     );
 }

--- a/src/main/java/com/iexec/sms/authorization/AuthorizationService.java
+++ b/src/main/java/com/iexec/sms/authorization/AuthorizationService.java
@@ -38,8 +38,7 @@ import static com.iexec.sms.App.DOMAIN;
 @Service
 public class AuthorizationService {
 
-
-    private IexecHubService iexecHubService;
+    private final IexecHubService iexecHubService;
 
     public AuthorizationService(IexecHubService iexecHubService) {
         this.iexecHubService = iexecHubService;
@@ -151,13 +150,11 @@ public class AuthorizationService {
 
     public String getChallengeForSetRequesterAppComputeSecret(
             String requesterAddress,
-            String appAddress,
             long secretIndex,
             String secretValue) {
         return HashUtils.concatenateAndHash(
                 Hash.sha3String(DOMAIN),
                 requesterAddress,
-                appAddress,
                 Long.toHexString(secretIndex),
                 Hash.sha3String(secretValue));
     }

--- a/src/main/java/com/iexec/sms/secret/compute/AppComputeSecretController.java
+++ b/src/main/java/com/iexec/sms/secret/compute/AppComputeSecretController.java
@@ -16,10 +16,8 @@
 
 package com.iexec.sms.secret.compute;
 
-import com.iexec.common.contract.generated.Ownable;
 import com.iexec.common.utils.BytesUtils;
 import com.iexec.sms.authorization.AuthorizationService;
-import com.iexec.sms.blockchain.IexecHubService;
 import com.iexec.sms.secret.SecretUtils;
 import com.iexec.common.web.ApiResponseBody;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +25,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.text.MessageFormat;
 import java.util.*;
 
 @Slf4j
@@ -36,18 +35,15 @@ public class AppComputeSecretController {
     private final AuthorizationService authorizationService;
     private final TeeTaskComputeSecretService teeTaskComputeSecretService;
     private final TeeTaskComputeSecretCountService teeTaskComputeSecretCountService;
-    private final IexecHubService iexecHubService;
 
     private static final ApiResponseBody<String> invalidAuthorizationPayload = createErrorPayload("Invalid authorization");
 
     public AppComputeSecretController(AuthorizationService authorizationService,
                                       TeeTaskComputeSecretService teeTaskComputeSecretService,
-                                      TeeTaskComputeSecretCountService teeTaskComputeSecretCountService,
-                                      IexecHubService iexecHubService) {
+                                      TeeTaskComputeSecretCountService teeTaskComputeSecretCountService) {
         this.authorizationService = authorizationService;
         this.teeTaskComputeSecretService = teeTaskComputeSecretService;
         this.teeTaskComputeSecretCountService = teeTaskComputeSecretCountService;
-        this.iexecHubService = iexecHubService;
     }
 
     // region App developer endpoints
@@ -206,41 +202,27 @@ public class AppComputeSecretController {
     // endregion
 
     // region App requester endpoint
-    @PostMapping("/requesters/{requesterAddress}/apps/{appAddress}/secrets/{secretIndex}")
+    @PostMapping("/requesters/{requesterAddress}/secrets/{secretIndex}")
     public ResponseEntity<ApiResponseBody<String>> addRequesterAppComputeSecret(@RequestHeader("Authorization") String authorization,
                                                                             @PathVariable String requesterAddress,
-                                                                            @PathVariable String appAddress,
                                                                             @PathVariable long secretIndex,
                                                                             @RequestBody String secretValue) {
         String challenge = authorizationService.getChallengeForSetRequesterAppComputeSecret(
                 requesterAddress,
-                appAddress,
                 secretIndex,
                 secretValue
         );
 
         if (!authorizationService.isSignedByHimself(challenge, authorization, requesterAddress)) {
             log.error("Unauthorized to addRequesterAppComputeSecret" +
-                            " [requesterAddress:{}, appAddress:{}, expectedChallenge:{}]",
-                    requesterAddress, appAddress, challenge);
+                            " [requesterAddress:{}, expectedChallenge:{}]",
+                    requesterAddress, challenge);
             return ResponseEntity
                     .status(HttpStatus.UNAUTHORIZED)
                     .body(invalidAuthorizationPayload);
         }
 
-        final Ownable appContract = iexecHubService.getOwnableContract(appAddress);
-        if (appContract == null
-                || BytesUtils.EMPTY_ADDRESS.equals(appAddress)
-                || !Objects.equals(appContract.getContractAddress(), appAddress)) {
-            log.debug("App does not exist" +
-                            " [requesterAddress:{}, appAddress:{}]",
-                    requesterAddress, appAddress);
-            return ResponseEntity
-                    .status(HttpStatus.NOT_FOUND)
-                    .body(createErrorPayload("App does not exist"));
-        }
-
-        final List<String> badRequestErrors = validateRequesterAppComputeSecret(requesterAddress, appAddress, secretIndex, secretValue);
+        final List<String> badRequestErrors = validateRequesterAppComputeSecret(requesterAddress, secretIndex, secretValue);
         if (!badRequestErrors.isEmpty()) {
             return ResponseEntity
                     .badRequest()
@@ -249,13 +231,13 @@ public class AppComputeSecretController {
 
         if (teeTaskComputeSecretService.isSecretPresent(
                 OnChainObjectType.APPLICATION,
-                appAddress,
+                "",
                 SecretOwnerRole.REQUESTER,
                 requesterAddress,
                 secretIndex)) {
             log.debug("Can't add requester secret as it already exists" +
-                            " [requesterAddress:{}, appAddress:{}, secretIndex:{}]",
-                    requesterAddress, appAddress, secretIndex);
+                            " [requesterAddress:{}, secretIndex:{}]",
+                    requesterAddress, secretIndex);
             return ResponseEntity
                     .status(HttpStatus.CONFLICT)
                     .body(createErrorPayload("Secret already exists"));
@@ -263,7 +245,7 @@ public class AppComputeSecretController {
 
         teeTaskComputeSecretService.encryptAndSaveSecret(
                 OnChainObjectType.APPLICATION,
-                appAddress,
+                "",
                 SecretOwnerRole.REQUESTER,
                 requesterAddress,
                 secretIndex,
@@ -274,83 +256,50 @@ public class AppComputeSecretController {
 
     private List<String> validateRequesterAppComputeSecret(
             String requesterAddress,
-            String appAddress,
             long secretIndex,
             String secretValue) {
         List<String> errors = new ArrayList<>();
 
-        // TODO: remove following bloc once functioning has been validated
-        if (secretIndex > 0) {
-            final String errorMessage = "Can't add more than a single app requester secret as of now.";
-            log.debug(errorMessage +
-                            " [requesterAddress:{}, appAddress:{}, secretIndex:{}]",
-                    requesterAddress, appAddress, secretIndex);
-            errors.add(errorMessage);
-        }
+        String messageDetails = MessageFormat.format("[requester: {0}, secretIndex: {1}]",
+                requesterAddress, secretIndex);
 
         if (secretIndex < 0) {
             final String errorMessage = "Negative index are forbidden for app requester secrets.";
-            log.debug(errorMessage +
-                            " [requesterAddress:{}, appAddress:{}, secretIndex:{}]",
-                    requesterAddress, appAddress, secretIndex);
+            log.debug("{} {}", errorMessage, messageDetails);
             errors.add(errorMessage);
         }
 
         if (!SecretUtils.isSecretSizeValid(secretValue)) {
             final String errorMessage = "Secret size should not exceed 4 Kb";
-            log.debug(errorMessage +
-                            " [requesterAddress:{}, appAddress:{}, secretIndex:{}, secretLength:{}]",
-                    requesterAddress, appAddress, secretIndex, secretValue.length()
-                    );
+            log.debug("{} [requesterAddress:{}, secretIndex:{}, secretLength:{}]",
+                    errorMessage, requesterAddress, secretIndex, secretValue.length()
+            );
             errors.add(errorMessage);
-        }
-
-        final Optional<TeeTaskComputeSecretCount> oAllowedSecretsCount =
-                teeTaskComputeSecretCountService.getMaxAppComputeSecretCount(
-                        appAddress,
-                        SecretOwnerRole.REQUESTER
-                );
-
-        if (oAllowedSecretsCount.isEmpty()) {
-            log.error("Can't add requester secret as no secret count has been provided" +
-                            " [requesterAddress:{}, appAddress:{}, secretIndex:{}]",
-                    requesterAddress, appAddress, secretIndex);
-            errors.add("No secret count has been provided");
-        } else {
-            final Integer allowedSecretsCount = oAllowedSecretsCount.get().getSecretCount();
-            if (secretIndex >= allowedSecretsCount) {
-                log.error("Can't add requester secret as index is greater than allowed secrets count" +
-                                " [requesterAddress:{}, appAddress:{}, secretIndex:{}, secretCount:{}]",
-                        requesterAddress, appAddress, secretIndex, allowedSecretsCount);
-                errors.add("Index is greater than allowed secrets count");
-            }
         }
 
         return errors;
     }
 
-    @RequestMapping(method = RequestMethod.HEAD, path = "/requesters/{requesterAddress}/apps/{appAddress}/secrets/{secretIndex}")
+    @RequestMapping(method = RequestMethod.HEAD, path = "/requesters/{requesterAddress}/secrets/{secretIndex}")
     public ResponseEntity<ApiResponseBody<String>> isRequesterAppComputeSecretPresent(
             @PathVariable String requesterAddress,
-            @PathVariable String appAddress,
             @PathVariable long secretIndex) {
         final boolean isSecretPresent = teeTaskComputeSecretService.isSecretPresent(
                 OnChainObjectType.APPLICATION,
-                appAddress,
+                "",
                 SecretOwnerRole.REQUESTER,
                 requesterAddress,
                 secretIndex
         );
+
+        String messageDetails = MessageFormat.format("[requester: {0}, secretIndex: {1}]",
+                requesterAddress, secretIndex);
         if (isSecretPresent) {
-            log.debug("App requester secret found" +
-                            " [requester: {}, appAddress: {}, secretIndex: {}]",
-                    requesterAddress, appAddress, secretIndex);
+            log.debug("App requester secret found {}", messageDetails);
             return ResponseEntity.noContent().build();
         }
 
-        log.debug("App requester secret not found " +
-                        " [requester: {}, appAddress: {}, secretIndex: {}]",
-                requesterAddress, appAddress, secretIndex);
+        log.debug("App requester secret not found {}", messageDetails);
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
                 .body(createErrorPayload("Secret not found"));

--- a/src/main/java/com/iexec/sms/tee/session/palaemon/PalaemonSessionService.java
+++ b/src/main/java/com/iexec/sms/tee/session/palaemon/PalaemonSessionService.java
@@ -77,8 +77,6 @@ public class PalaemonSessionService {
     // Compute
     static final String APP_MRENCLAVE = "APP_MRENCLAVE";
     static final String APP_ARGS = "APP_ARGS";
-    static final String IEXEC_APP_DEVELOPER_SECRET_PREFIX = "IEXEC_APP_DEVELOPER_SECRET_";
-    static final String IEXEC_REQUESTER_SECRET_PREFIX = "IEXEC_REQUESTER_SECRET_";
     // PostCompute
     static final String POST_COMPUTE_MRENCLAVE = "POST_COMPUTE_MRENCLAVE";
     static final String POST_COMPUTE_ENTRYPOINT = "POST_COMPUTE_ENTRYPOINT";
@@ -248,7 +246,7 @@ public class PalaemonSessionService {
                                 secretIndex)
                         .map(TeeTaskComputeSecret::getValue)
                         .orElse(EMPTY_YML_VALUE);
-        tokens.put(IEXEC_APP_DEVELOPER_SECRET_PREFIX + secretIndex, appDeveloperSecret0);
+        tokens.put(IexecEnvUtils.IEXEC_APP_DEVELOPER_SECRET_PREFIX + secretIndex, appDeveloperSecret0);
 
         for (Map.Entry<String, String> secretEntry: taskDescription.getSecrets().entrySet()) {
             String requesterSecret =
@@ -260,7 +258,7 @@ public class PalaemonSessionService {
                                     Long.parseLong(secretEntry.getValue()))
                             .map(TeeTaskComputeSecret::getValue)
                             .orElse(EMPTY_YML_VALUE);
-            tokens.put(IEXEC_REQUESTER_SECRET_PREFIX + secretEntry.getKey(), requesterSecret);
+            tokens.put(IexecEnvUtils.IEXEC_REQUESTER_SECRET_PREFIX + secretEntry.getKey(), requesterSecret);
         }
 
         return tokens;

--- a/src/main/java/com/iexec/sms/tee/session/palaemon/PalaemonSessionService.java
+++ b/src/main/java/com/iexec/sms/tee/session/palaemon/PalaemonSessionService.java
@@ -250,16 +250,18 @@ public class PalaemonSessionService {
                         .orElse(EMPTY_YML_VALUE);
         tokens.put(IEXEC_APP_DEVELOPER_SECRET_PREFIX + secretIndex, appDeveloperSecret0);
 
-        String requesterSecret0 =
-                teeTaskComputeSecretService.getSecret(
-                                OnChainObjectType.APPLICATION,
-                                taskDescription.getAppAddress(),
-                                SecretOwnerRole.REQUESTER,
-                                taskDescription.getRequester(),
-                                secretIndex)
-                        .map(TeeTaskComputeSecret::getValue)
-                        .orElse(EMPTY_YML_VALUE);
-        tokens.put(IEXEC_REQUESTER_SECRET_PREFIX + secretIndex, requesterSecret0);
+        for (Map.Entry<String, String> secretEntry: taskDescription.getSecrets().entrySet()) {
+            String requesterSecret =
+                    teeTaskComputeSecretService.getSecret(
+                                    OnChainObjectType.APPLICATION,
+                                    "",
+                                    SecretOwnerRole.REQUESTER,
+                                    taskDescription.getRequester(),
+                                    Long.parseLong(secretEntry.getValue()))
+                            .map(TeeTaskComputeSecret::getValue)
+                            .orElse(EMPTY_YML_VALUE);
+            tokens.put(IEXEC_REQUESTER_SECRET_PREFIX + secretEntry.getKey(), requesterSecret);
+        }
 
         return tokens;
     }

--- a/src/test/java/com/iexec/sms/authorization/AuthorizationServiceTests.java
+++ b/src/test/java/com/iexec/sms/authorization/AuthorizationServiceTests.java
@@ -106,6 +106,14 @@ class AuthorizationServiceTests {
     }
 
     @Test
+    void getChallengeForSetRequesterAppComputeSecret() {
+        String challenge = authorizationService.getChallengeForSetRequesterAppComputeSecret(
+                "", 0L, "");
+        Assertions.assertEquals("0xc0fdb70946e46bb7ce49790d475b58f08c59a296389af3d8a15779abe1d6dc6d",
+                challenge);
+    }
+
+    @Test
     void getChallengeForSetWeb3Secret() {
         String secretAddress = "0x123";
         String secretValue = "ghijk";

--- a/src/test/java/com/iexec/sms/tee/session/palaemon/PalaemonSessionServiceTests.java
+++ b/src/test/java/com/iexec/sms/tee/session/palaemon/PalaemonSessionServiceTests.java
@@ -190,10 +190,11 @@ class PalaemonSessionServiceTests {
     // app
 
     @Test
-    void shouldGetAppPalaemonTokens() throws Exception {
+    void shouldGetAppPalaemonTokens() {
         PalaemonSessionRequest request = createSessionRequest();
         TeeEnclaveConfigurationValidator validator = mock(TeeEnclaveConfigurationValidator.class);
-        final int secretIndex = 0;
+        final long applicationDeveloperSecretIndex = 0;
+        final long requesterSecretIndex = 2;
 
         when(enclaveConfig.getValidator()).thenReturn(validator);
         when(validator.isValid()).thenReturn(true);
@@ -202,29 +203,29 @@ class PalaemonSessionServiceTests {
                 APP_ADDRESS,
                 SecretOwnerRole.APPLICATION_DEVELOPER,
                 "",
-                secretIndex))
+                applicationDeveloperSecretIndex))
                 .thenReturn(Optional.of(TeeTaskComputeSecret
                         .builder()
                         .onChainObjectType(OnChainObjectType.APPLICATION)
                         .onChainObjectAddress(APP_ADDRESS)
                         .secretOwnerRole(SecretOwnerRole.APPLICATION_DEVELOPER)
-                        .index(secretIndex)
+                        .index(applicationDeveloperSecretIndex)
                         .value(APP_DEVELOPER_SECRET_VALUE)
                         .build()
                 ));
         when(teeTaskComputeSecretService.getSecret(
                 OnChainObjectType.APPLICATION,
-                APP_ADDRESS,
+                "",
                 SecretOwnerRole.REQUESTER,
                 REQUESTER,
-                secretIndex))
+                requesterSecretIndex))
                 .thenReturn(Optional.of(TeeTaskComputeSecret
                         .builder()
                         .onChainObjectType(OnChainObjectType.APPLICATION)
-                        .onChainObjectAddress(APP_ADDRESS)
+                        .onChainObjectAddress("")
                         .secretOwnerRole(SecretOwnerRole.REQUESTER)
                         .fixedSecretOwner(REQUESTER)
-                        .index(secretIndex)
+                        .index(requesterSecretIndex)
                         .value(REQUESTER_SECRET_VALUE)
                         .build()
                 ));
@@ -246,7 +247,7 @@ class PalaemonSessionServiceTests {
     }
 
     @Test
-    void shouldGetPalaemonTokensWithoutAppComputeSecret() throws Exception {
+    void shouldGetPalaemonTokensWithoutAppComputeSecret() {
         PalaemonSessionRequest request = createSessionRequest();
         TeeEnclaveConfigurationValidator validator = mock(TeeEnclaveConfigurationValidator.class);
         final int secretIndex = 0;
@@ -262,7 +263,7 @@ class PalaemonSessionServiceTests {
                 .thenReturn(Optional.empty());
         when(teeTaskComputeSecretService.getSecret(
                 OnChainObjectType.APPLICATION,
-                APP_ADDRESS,
+                "",
                 SecretOwnerRole.REQUESTER,
                 REQUESTER,
                 secretIndex))
@@ -376,6 +377,7 @@ class PalaemonSessionServiceTests {
                 .isResultEncryption(true)
                 .resultStorageProvider(STORAGE_PROVIDER)
                 .resultStorageProxy(STORAGE_PROXY)
+                .secrets(Map.of("0", "2"))
                 .botSize(1)
                 .botFirstIndex(0)
                 .botIndex(0)


### PR DESCRIPTION
Here comes the beginning of the review.

For the moment, **requester secret key** is still a `long`.

Several checks have disappeared:
* requester can publish several secrets
* several secrets  can be defined in `DealParams` and used to populate **palaemon session**
* no check on application existence
* no check on consistency with requester secret counts

Pending points:
* how to have both app developer secret index (Long) and requester secret key (String) in `TeeTaskComputeSecret`
* which checks need to be performed and where ?